### PR TITLE
Connect TaskForm to Gantt display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,76 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import React, { useState } from 'react';
+import './App.css';
+import './components/tasks.css';
+
+import type { Task } from '@/types';
+import { GanttChart } from '@/features/gantt';
+import {
+  TaskForm,
+  TaskDetailsModal,
+  useTasks,
+} from '@/features/tasks';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const {
+    tasks,
+    addTask,
+    updateTask,
+    deleteTask,
+  } = useTasks();
+
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const [year, setYear] = useState<number>(new Date().getFullYear());
+  const [quarter, setQuarter] = useState<1 | 2 | 3 | 4>(
+    (Math.ceil((new Date().getMonth() + 1) / 3) as 1 | 2 | 3 | 4)
+  );
+
+  const handleAddTask = async (task: Omit<Task, 'id'>) => {
+    await addTask(task);
+  };
+
+  const handleTaskClick = (task: Task) => {
+    setSelectedTask(task);
+  };
+
+  const handleQuarterChange = (newYear: number, newQuarter: 1 | 2 | 3 | 4) => {
+    setYear(newYear);
+    setQuarter(newQuarter);
+  };
+
+  const handleEditTask = async (
+    taskId: string,
+    updatedTask: Omit<Task, 'id'>
+  ) => {
+    return updateTask(taskId, updatedTask);
+  };
+
+  const handleDeleteTask = async (taskId: string) => {
+    return deleteTask(taskId);
+  };
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <div className="app-container">
+      <div className="task-form-container">
+        <TaskForm onSubmit={handleAddTask} />
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
+      <div className="gantt-container">
+        <GanttChart
+          tasks={tasks}
+          currentYear={year}
+          currentQuarter={quarter}
+          onTaskClick={handleTaskClick}
+          onQuarterChange={handleQuarterChange}
+        />
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+      <TaskDetailsModal
+        task={selectedTask}
+        isOpen={!!selectedTask}
+        onClose={() => setSelectedTask(null)}
+        onEdit={handleEditTask}
+        onDelete={handleDeleteTask}
+      />
+    </div>
+  );
 }
 
-export default App
+export default App;


### PR DESCRIPTION
## Summary
- Integrate task management with Gantt chart by combining TaskForm, GanttChart, and TaskDetailsModal in the app
- Manage tasks, quarter navigation, and task selection via useTasks hook

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68b6db3adbd4832a843c9335df82e25f