### PR TITLE
Add stylesheet for Gantt chart components

### DIFF
--- a/src/features/gantt/components/GanttChart.tsx
+++ b/src/features/gantt/components/GanttChart.tsx
@@ -35,6 +35,7 @@
  */
 
 import React, { useCallback } from 'react';
+import '../gantt.css';
 import type { Task } from '../../../types';
 import { QuarterNavigation } from './QuarterNavigation';
 import { Timeline } from './Timeline';

--- a/src/features/gantt/components/QuarterNavigation.tsx
+++ b/src/features/gantt/components/QuarterNavigation.tsx
@@ -42,6 +42,7 @@
  */
 
 import React, { useCallback } from 'react';
+import '../gantt.css';
 import { useQuarterNavigation } from '../hooks/useQuarterNavigation';
 
 interface QuarterNavigationProps {

--- a/src/features/gantt/gantt.css
+++ b/src/features/gantt/gantt.css
@@ -1,0 +1,183 @@
+/* Styles for Gantt chart components */
+
+.gantt-chart {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  background-color: #fff;
+  font-size: 14px;
+}
+
+.gantt-header {
+  display: flex;
+  flex-direction: column;
+  background-color: #f8fafc;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.quarter-navigation {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+
+.nav-button {
+  background: #e5e7eb;
+  border: none;
+  border-radius: 4px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.nav-button:hover:not(:disabled) {
+  background: #d1d5db;
+}
+
+.nav-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.quarter-label h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.timeline-header,
+.gantt-body {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+}
+
+.task-names-column {
+  background: #f1f5f9;
+  border-right: 1px solid #e5e7eb;
+  position: relative;
+}
+
+.column-header {
+  padding: 0.5rem;
+  font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.timeline-months {
+  display: flex;
+}
+
+.month-header {
+  flex: 1;
+  text-align: center;
+  padding: 0.5rem 0;
+  border-left: 1px solid #e5e7eb;
+  background: #f8fafc;
+}
+
+.gantt-content {
+  position: relative;
+  overflow: hidden;
+}
+
+.gantt-body {
+  position: relative;
+  overflow: hidden;
+}
+
+.timeline-area {
+  position: relative;
+  flex: 1;
+}
+
+.timeline-grid {
+  position: absolute;
+  inset: 0;
+  display: flex;
+}
+
+.month-column {
+  flex: 1;
+  border-left: 1px solid #e5e7eb;
+}
+
+.task-name-row {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.task-name-label {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 0.5rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.task-name-label:hover {
+  background: #e2e8f0;
+}
+
+.task-bar {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.task-bar.hovered {
+  filter: brightness(1.1);
+}
+
+.task-bar-content {
+  padding: 0 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.continuation-left,
+.continuation-right {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 12px;
+  pointer-events: none;
+}
+
+.continuation-left {
+  left: 2px;
+}
+
+.continuation-right {
+  right: 2px;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  color: #9ca3af;
+  text-align: center;
+}
+
+.empty-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- add dedicated `gantt.css` with layout, navigation button, timeline grid, hover and empty-state styles
- wire stylesheet into `GanttChart` and `QuarterNavigation` components

## Testing
- `npm run lint`
- `npm run test:run`
