### PR TITLE
Toggle task form view in Gantt chart

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -11,12 +11,6 @@
   height: 100%;
 }
 
-.task-form-container {
-  width: 320px;
-  padding: 1rem;
-  overflow-y: auto;
-}
-
 .gantt-container {
   flex: 1;
   overflow: auto;
@@ -28,7 +22,4 @@
     flex-direction: column;
   }
 
-  .task-form-container {
-    width: 100%;
-  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import './components/tasks.css';
 import type { Task } from '@/types';
 import { GanttChart } from '@/features/gantt';
 import {
-  TaskForm,
   TaskDetailsModal,
   useTasks,
 } from '@/features/tasks';
@@ -50,9 +49,6 @@ function App() {
 
   return (
     <div className="app-container">
-      <div className="task-form-container">
-        <TaskForm onSubmit={handleAddTask} />
-      </div>
       <div className="gantt-container">
         <GanttChart
           tasks={tasks}
@@ -60,6 +56,7 @@ function App() {
           currentQuarter={quarter}
           onTaskClick={handleTaskClick}
           onQuarterChange={handleQuarterChange}
+          onAddTask={handleAddTask}
         />
       </div>
       <TaskDetailsModal

--- a/src/features/gantt/gantt.css
+++ b/src/features/gantt/gantt.css
@@ -16,6 +16,13 @@
   border-bottom: 1px solid #e5e7eb;
 }
 
+.gantt-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem;
+}
+
 .quarter-navigation {
   display: flex;
   align-items: center;
@@ -89,6 +96,11 @@
 .gantt-body {
   position: relative;
   overflow: hidden;
+}
+
+.gantt-body.task-form-view {
+  display: block;
+  padding: 1rem;
 }
 
 .timeline-area {


### PR DESCRIPTION
## Summary
- move task creation form into gantt body and add toolbar button to toggle between chart and form views
- disable quarter navigation while the form is visible to prevent chart changes
- clean up unused top-level form container and add supporting styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba9fe6bfcc832aba48ce0c19d4579b