### PR TITLE
Move timeline header and add responsive year scroll

### DIFF
--- a/src/features/gantt/components/GanttChart.tsx
+++ b/src/features/gantt/components/GanttChart.tsx
@@ -158,7 +158,10 @@ export const GanttChart: React.FC<GanttChartProps> = ({
             {panelMode === 'chart' ? GANTT_ACTIONS.ADD_TASK : GANTT_ACTIONS.VIEW_CHART}
           </Button>
         </div>
+      </div>
 
+      {/* Chart content */}
+      <div className={`gantt-content ${viewMode === 'year' ? 'year-view' : ''}`}>
         {/* Timeline months header */}
         <div className="timeline-header">
           <div className="timeline-months">
@@ -173,10 +176,7 @@ export const GanttChart: React.FC<GanttChartProps> = ({
             ))}
           </div>
         </div>
-      </div>
 
-      {/* Chart content */}
-      <div className="gantt-content">
         {panelMode === 'add' ? (
           <div className="gantt-body task-form-view">
             <TaskForm onSubmit={handleAddTask} onCancel={() => setPanelMode('chart')} />

--- a/src/features/gantt/gantt.css
+++ b/src/features/gantt/gantt.css
@@ -75,6 +75,10 @@
   background: #f8fafc;
 }
 
+.timeline-header {
+  border-bottom: 1px solid #e5e7eb;
+}
+
 .gantt-content {
   position: relative;
   overflow: hidden;
@@ -167,5 +171,16 @@
 .empty-icon {
   font-size: 2rem;
   margin-bottom: 0.5rem;
+}
+
+@media (max-width: 968px) {
+  .gantt-content.year-view {
+    overflow-x: scroll;
+  }
+
+  .gantt-content.year-view .timeline-header,
+  .gantt-content.year-view .gantt-body {
+    min-width: 1000px;
+  }
 }
 


### PR DESCRIPTION
## Summary
- Move timeline month header into `gantt-content` so it scrolls with the chart
- Add year-view class and mobile styles to enforce 1000px width and horizontal scrolling on small screens
- Give timeline header a bottom border for clearer separation

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd69a5c0e0832abcdcc6e0f4d2444d