### PR TITLE
Add unit tests for Gantt chart components

### DIFF
--- a/src/features/gantt/components/__tests__/GanttChart.test.tsx
+++ b/src/features/gantt/components/__tests__/GanttChart.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { GanttChart } from '../GanttChart';
+import { GANTT_ACTIONS, GANTT_NAVIGATION } from '../../constants';
+
+const baseProps = {
+  currentYear: 2024,
+  currentQuarter: 1 as 1,
+  tasks: [],
+  onQuarterChange: vi.fn(),
+};
+
+describe('GanttChart', () => {
+  it('renders quarter months', () => {
+    render(<GanttChart {...baseProps} />);
+    expect(screen.getByText('Jaanuar')).toBeInTheDocument();
+    expect(screen.getByText('Veebruar')).toBeInTheDocument();
+    expect(screen.getByText('Märts')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no tasks', () => {
+    render(<GanttChart {...baseProps} />);
+    expect(screen.getByText('Aasta 2024 Q1 puuduvad ülesanded')).toBeInTheDocument();
+  });
+
+  it('calls onQuarterChange when navigating next', () => {
+    render(<GanttChart {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: GANTT_NAVIGATION.NEXT_QUARTER }));
+    expect(baseProps.onQuarterChange).toHaveBeenCalledWith(2024, 2);
+  });
+
+  it('shows task form when add task is clicked', () => {
+    render(<GanttChart {...baseProps} />);
+    fireEvent.click(screen.getByText(GANTT_ACTIONS.ADD_TASK));
+    expect(screen.getByText('Add Task')).toBeInTheDocument();
+  });
+});

--- a/src/features/gantt/components/__tests__/QuarterNavigation.test.tsx
+++ b/src/features/gantt/components/__tests__/QuarterNavigation.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QuarterNavigation } from '../QuarterNavigation';
+import { GANTT_NAVIGATION } from '../../constants';
+
+describe('QuarterNavigation', () => {
+  const onQuarterChange = vi.fn();
+  const onViewModeChange = vi.fn();
+
+  beforeEach(() => {
+    onQuarterChange.mockClear();
+    onViewModeChange.mockClear();
+  });
+
+  it('displays current quarter label', () => {
+    render(
+      <QuarterNavigation
+        currentYear={2024}
+        currentQuarter={1}
+        viewMode="quarter"
+        onQuarterChange={onQuarterChange}
+      />
+    );
+    expect(screen.getByText('Q1 2024')).toBeInTheDocument();
+  });
+
+  it('calls onQuarterChange when next is clicked', () => {
+    render(
+      <QuarterNavigation
+        currentYear={2024}
+        currentQuarter={1}
+        viewMode="quarter"
+        onQuarterChange={onQuarterChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: GANTT_NAVIGATION.NEXT_QUARTER }));
+    expect(onQuarterChange).toHaveBeenCalledWith(2024, 2);
+  });
+
+  it('calls onQuarterChange when previous is clicked', () => {
+    render(
+      <QuarterNavigation
+        currentYear={2024}
+        currentQuarter={1}
+        viewMode="quarter"
+        onQuarterChange={onQuarterChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: GANTT_NAVIGATION.PREVIOUS_QUARTER }));
+    expect(onQuarterChange).toHaveBeenCalledWith(2023, 4);
+  });
+
+  it('switches view mode when segmented control is clicked', () => {
+    render(
+      <QuarterNavigation
+        currentYear={2024}
+        currentQuarter={1}
+        viewMode="quarter"
+        onQuarterChange={onQuarterChange}
+        onViewModeChange={onViewModeChange}
+      />
+    );
+    fireEvent.click(screen.getByText('Aasta'));
+    expect(onViewModeChange).toHaveBeenCalledWith('year');
+  });
+
+  it('navigates to today when Today button is clicked', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 6, 1));
+
+    render(
+      <QuarterNavigation
+        currentYear={2024}
+        currentQuarter={1}
+        viewMode="quarter"
+        onQuarterChange={onQuarterChange}
+        showTodayButton
+      />
+    );
+    fireEvent.click(screen.getByText(GANTT_NAVIGATION.TODAY));
+    expect(onQuarterChange).toHaveBeenCalledWith(2025, 3);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/features/gantt/components/__tests__/TaskBar.test.tsx
+++ b/src/features/gantt/components/__tests__/TaskBar.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TaskBar } from '../TaskBar';
+import type { TaskBarData } from '../../types/gantt.types';
+
+const baseTask: TaskBarData = {
+  id: '1',
+  name: 'Task 1',
+  startDate: new Date(2024, 0, 1),
+  endDate: new Date(2024, 0, 5),
+  color: '#000',
+  left: 10,
+  width: 50,
+  row: 0,
+  isPartial: false,
+  continuesLeft: false,
+  continuesRight: false,
+};
+
+describe('TaskBar', () => {
+  const renderBar = (task: TaskBarData = baseTask, props: any = {}) =>
+    render(<TaskBar task={task} rowHeight={40} taskHeight={20} {...props} />);
+
+  it('renders task name', () => {
+    renderBar();
+    expect(screen.getByText('Task 1')).toBeInTheDocument();
+  });
+
+  it('fires onClick handler', () => {
+    const onClick = vi.fn();
+    renderBar(baseTask, { onClick });
+    fireEvent.click(screen.getByText('Task 1'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('handles hover events', () => {
+    const onHover = vi.fn();
+    const { container } = renderBar(baseTask, { onHover });
+    const bar = container.querySelector('.task-bar')!;
+    fireEvent.mouseEnter(bar);
+    expect(onHover).toHaveBeenCalledWith('1');
+    fireEvent.mouseLeave(bar);
+    expect(onHover).toHaveBeenCalledWith(null);
+  });
+
+  it('shows continuation indicators', () => {
+    const { container } = renderBar({ ...baseTask, continuesLeft: true, continuesRight: true });
+    expect(container.querySelector('.continuation-left')).toBeInTheDocument();
+    expect(container.querySelector('.continuation-right')).toBeInTheDocument();
+  });
+});

--- a/src/features/gantt/components/__tests__/Timeline.test.tsx
+++ b/src/features/gantt/components/__tests__/Timeline.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Timeline } from '../Timeline';
+import type { TimelineData, TaskBarData } from '../../types/gantt.types';
+
+const timelineData: TimelineData = {
+  year: 2024,
+  quarter: 1,
+  mode: 'quarter',
+  startDate: new Date(2024, 0, 1),
+  endDate: new Date(2024, 2, 31),
+  months: [
+    { name: 'Jaanuar', date: new Date(2024, 0, 1), daysInMonth: 31 },
+    { name: 'Veebruar', date: new Date(2024, 1, 1), daysInMonth: 29 },
+    { name: 'Märts', date: new Date(2024, 2, 1), daysInMonth: 31 },
+  ],
+};
+
+const task1: TaskBarData = {
+  id: '1',
+  name: 'Task 1',
+  startDate: new Date(2024, 0, 1),
+  endDate: new Date(2024, 0, 5),
+  color: '#000',
+  left: 0,
+  width: 30,
+  row: 0,
+  isPartial: false,
+  continuesLeft: false,
+  continuesRight: false,
+};
+
+const task2: TaskBarData = { ...task1, id: '2', name: 'Task 2', left: 40 };
+
+describe('Timeline', () => {
+  it('renders month columns for each month', () => {
+    const { container } = render(
+      <Timeline timelineData={timelineData} tasks={[]} rowHeight={40} taskHeight={20} />
+    );
+    expect(container.getElementsByClassName('month-column').length).toBe(3);
+  });
+
+  it('renders task bars', () => {
+    render(
+      <Timeline timelineData={timelineData} tasks={[task1, task2]} rowHeight={40} taskHeight={20} />
+    );
+    expect(screen.getByText('Task 1')).toBeInTheDocument();
+    expect(screen.getByText('Task 2')).toBeInTheDocument();
+  });
+
+  it('calls onTaskClick when a task is clicked', () => {
+    const onTaskClick = vi.fn();
+    render(
+      <Timeline timelineData={timelineData} tasks={[task1]} rowHeight={40} taskHeight={20} onTaskClick={onTaskClick} />
+    );
+    fireEvent.click(screen.getByText('Task 1'));
+    expect(onTaskClick).toHaveBeenCalled();
+  });
+
+  it('marks task as hovered on mouse enter', () => {
+    const { container } = render(
+      <Timeline timelineData={timelineData} tasks={[task1]} rowHeight={40} taskHeight={20} />
+    );
+    const bar = container.querySelector('.task-bar')!;
+    fireEvent.mouseEnter(bar);
+    expect(bar).toHaveClass('hovered');
+    fireEvent.mouseLeave(bar);
+    expect(bar).not.toHaveClass('hovered');
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for GanttChart including empty state, navigation and add-task mode
- test QuarterNavigation controls, view switch and today shortcut
- verify TaskBar interactions and Timeline rendering/hover behavior

## Testing
- `npm test`