### PR TITLE
Add tests for tasks feature components

### DIFF
--- a/src/features/tasks/components/__tests__/DetailsView.test.tsx
+++ b/src/features/tasks/components/__tests__/DetailsView.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DetailsView } from '../DetailsView';
+import { TASKS_ACTIONS } from '../../constants';
+import { VALIDATION_MESSAGES } from '@/utils/constants';
+
+const baseTask = {
+  id: '1',
+  name: 'Test Task',
+  startDate: new Date(2024, 0, 1),
+  endDate: new Date(2024, 0, 5),
+  color: '#3B82F6',
+};
+
+describe('DetailsView', () => {
+  beforeAll(() => {
+    // antd uses matchMedia internally; provide a stub for jsdom
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+  it('renders task details', () => {
+    render(
+      <DetailsView
+        task={baseTask}
+        onEdit={vi.fn()}
+        onBack={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(baseTask.name)).toBeInTheDocument();
+    expect(screen.getByText(baseTask.color)).toBeInTheDocument();
+    expect(screen.getByText('01.01.2024')).toBeInTheDocument();
+    expect(screen.getByText('05.01.2024')).toBeInTheDocument();
+    expect(screen.getByText(baseTask.id)).toBeInTheDocument();
+  });
+
+  it('calls action callbacks', () => {
+    const onEdit = vi.fn();
+    const onBack = vi.fn();
+    const onDelete = vi.fn();
+
+    render(
+      <DetailsView
+        task={baseTask}
+        onEdit={onEdit}
+        onBack={onBack}
+        onDelete={onDelete}
+      />
+    );
+
+    fireEvent.click(screen.getByText(TASKS_ACTIONS.EDIT));
+    fireEvent.click(screen.getByText(TASKS_ACTIONS.GO_BACK));
+    fireEvent.click(screen.getByText(TASKS_ACTIONS.DELETE));
+
+    expect(onEdit).toHaveBeenCalled();
+    expect(onBack).toHaveBeenCalled();
+    expect(onDelete).toHaveBeenCalled();
+  });
+
+  it('shows upcoming status for future task', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1));
+
+    const futureTask = { ...baseTask, startDate: new Date(2024, 0, 2), endDate: new Date(2024, 0, 3) };
+
+    render(
+      <DetailsView
+        task={futureTask}
+        onEdit={vi.fn()}
+        onBack={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(VALIDATION_MESSAGES.STATUS_UPCOMING)).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+});

--- a/src/features/tasks/components/__tests__/TaskForm.test.tsx
+++ b/src/features/tasks/components/__tests__/TaskForm.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TaskForm } from '../TaskForm';
+import { TASKS_ACTIONS } from '../../constants';
+import { VALIDATION_MESSAGES } from '@/utils/constants';
+import { formatDate } from '@/utils/dateUtils';
+
+describe('TaskForm', () => {
+  beforeAll(() => {
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it('submits valid form data', async () => {
+    const start = new Date();
+    const end = new Date();
+    end.setDate(end.getDate() + 3);
+
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TaskForm
+        onSubmit={onSubmit}
+        initialData={{
+          name: 'My Task',
+          startDateStr: formatDate(start),
+          endDateStr: formatDate(end),
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Task' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'My Task',
+        startDate: new Date(start.getFullYear(), start.getMonth(), start.getDate()),
+        endDate: new Date(end.getFullYear(), end.getMonth(), end.getDate()),
+        color: expect.any(String),
+      })
+    );
+  });
+
+  it('shows validation errors when fields are empty', () => {
+    const onSubmit = vi.fn();
+    render(<TaskForm onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add Task' }));
+
+    expect(screen.getByText(VALIDATION_MESSAGES.TASK_NAME_REQUIRED)).toBeInTheDocument();
+    expect(screen.getByText(VALIDATION_MESSAGES.START_DATE_REQUIRED)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancel = vi.fn();
+    render(<TaskForm onSubmit={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText(TASKS_ACTIONS.CANCEL));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/features/tasks/components/__tests__/TaskNotification.test.tsx
+++ b/src/features/tasks/components/__tests__/TaskNotification.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TaskNotification, type TaskNotificationRef } from '../TaskNotification';
+import { TASKS_NOTIFICATIONS } from '../../constants';
+
+const mockSuccess = vi.fn();
+const mockWarning = vi.fn();
+const mockInfo = vi.fn();
+
+vi.mock('antd', () => ({
+  notification: {
+    useNotification: () => [
+      { success: mockSuccess, warning: mockWarning, info: mockInfo },
+      <div />,
+    ],
+  },
+}));
+
+describe('TaskNotification', () => {
+  it('showAdd triggers success notification', () => {
+    const ref = { current: null } as React.RefObject<TaskNotificationRef>;
+    render(<TaskNotification ref={ref} />);
+
+    ref.current?.showAdd();
+    expect(mockSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ message: TASKS_NOTIFICATIONS.TASK_ADDED })
+    );
+  });
+
+  it('showDelete triggers warning notification with task name', () => {
+    const ref = { current: null } as React.RefObject<TaskNotificationRef>;
+    render(<TaskNotification ref={ref} />);
+
+    ref.current?.showDelete('Example');
+    expect(mockWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: `${TASKS_NOTIFICATIONS.TASK_DELETED} Example`,
+      })
+    );
+  });
+
+  it('showUpdate triggers info notification', () => {
+    const ref = { current: null } as React.RefObject<TaskNotificationRef>;
+    render(<TaskNotification ref={ref} />);
+
+    ref.current?.showUpdate();
+    expect(mockInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ message: TASKS_NOTIFICATIONS.TASK_UPDATED })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add DetailsView tests covering render, actions, and status handling
- create TaskForm tests for submission, validation, and cancel behavior
- implement TaskNotification tests for add/delete/update notifications

## Testing
- `npm test --silent`
