### PR TITLE
feat: add weekly timeline with current week highlight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "antd": "^5.27.2",
+        "clsx": "^2.1.0",
         "dayjs": "^1.11.18",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -2730,6 +2731,14 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "antd": "^5.27.2",
     "dayjs": "^1.11.18",
+    "clsx": "^2.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { clsx } from 'clsx';
+import clsx from 'clsx';
 
 export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   label?: string;

--- a/src/features/gantt/components/GanttChart.tsx
+++ b/src/features/gantt/components/GanttChart.tsx
@@ -131,6 +131,9 @@ export const GanttChart: React.FC<GanttChartProps> = ({
     endDateStr: formatDate(task.endDate)
   });
 
+  const totalDays = (timelineData.endDate.getTime() - timelineData.startDate.getTime()) / (1000 * 60 * 60 * 24) + 1;
+  const now = new Date();
+
   return (
     <div className={`gantt-chart ${className}`}>
       {/* Header with extracted navigation */}
@@ -174,6 +177,23 @@ export const GanttChart: React.FC<GanttChartProps> = ({
                 <span className="month-name">{month.name}</span>
               </div>
             ))}
+          </div>
+
+          <div className="timeline-weeks">
+            {timelineData.weeks.map((week) => {
+              const width = (week.days / totalDays) * 100;
+              const isCurrent = now >= week.startDate && now <= week.endDate;
+              return (
+                <div
+                  key={`week-${week.weekNumber}-${week.startDate.toISOString()}`}
+                  data-testid={`week-${week.weekNumber}`}
+                  className={`week-header${isCurrent ? ' current-week' : ''}`}
+                  style={{ width: `${width}%` }}
+                >
+                  <span className="week-number">{week.weekNumber}</span>
+                </div>
+              );
+            })}
           </div>
         </div>
 

--- a/src/features/gantt/components/Timeline.tsx
+++ b/src/features/gantt/components/Timeline.tsx
@@ -117,20 +117,34 @@ const TimelineComponent: React.FC<TimelineProps> = ({
   className = ''
 }) => {
   const [hovered, setHovered] = useState<string | null>(null);
+  const totalDays = (timelineData.endDate.getTime() - timelineData.startDate.getTime()) / (1000 * 60 * 60 * 24) + 1;
+  const now = new Date();
 
   return (
     <div className={`timeline-area ${className}`}>
       <div className="timeline-grid">
-        {timelineData.months.map((month, idx) => (
-          <div
-            key={month.name}
-            className="month-column"
-            style={{
-              left: `${(idx / timelineData.months.length) * 100}%`,
-              width: `${100 / timelineData.months.length}%`
-            }}
-          />
-        ))}
+        <div className="month-columns">
+          {timelineData.months.map((month) => (
+            <div
+              key={month.name}
+              className="month-column"
+              style={{ width: `${100 / timelineData.months.length}%` }}
+            />
+          ))}
+        </div>
+        <div className="week-columns">
+          {timelineData.weeks.map((week) => {
+            const width = (week.days / totalDays) * 100;
+            const isCurrent = now >= week.startDate && now <= week.endDate;
+            return (
+              <div
+                key={`week-${week.weekNumber}-${week.startDate.toISOString()}`}
+                className={`week-column${isCurrent ? ' current-week' : ''}`}
+                style={{ width: `${width}%` }}
+              />
+            );
+          })}
+        </div>
       </div>
 
       {tasks.map(task => (

--- a/src/features/gantt/components/__tests__/GanttChart.test.tsx
+++ b/src/features/gantt/components/__tests__/GanttChart.test.tsx
@@ -2,10 +2,11 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { GanttChart } from '../GanttChart';
 import { GANTT_ACTIONS, GANTT_NAVIGATION } from '../../constants';
+import { getWeekNumber } from '@/utils/dateUtils';
 
 const baseProps = {
   currentYear: 2024,
-  currentQuarter: 1 as 1,
+  currentQuarter: 1 as const,
   tasks: [],
   onQuarterChange: vi.fn(),
 };
@@ -16,6 +17,16 @@ describe('GanttChart', () => {
     expect(screen.getByText('Jaanuar')).toBeInTheDocument();
     expect(screen.getByText('Veebruar')).toBeInTheDocument();
     expect(screen.getByText('Märts')).toBeInTheDocument();
+  });
+
+  it('renders weeks and highlights current week', () => {
+    const currentDate = new Date(2024, 0, 10); // within week 2
+    vi.setSystemTime(currentDate);
+    render(<GanttChart {...baseProps} />);
+    const weekNumber = getWeekNumber(currentDate);
+    const weekEl = screen.getByTestId(`week-${weekNumber}`);
+    expect(weekEl).toHaveClass('current-week');
+    vi.useRealTimers();
   });
 
   it('shows empty state when no tasks', () => {

--- a/src/features/gantt/components/__tests__/TaskBar.test.tsx
+++ b/src/features/gantt/components/__tests__/TaskBar.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { TaskBar } from '../TaskBar';
@@ -18,8 +19,10 @@ const baseTask: TaskBarData = {
 };
 
 describe('TaskBar', () => {
-  const renderBar = (task: TaskBarData = baseTask, props: any = {}) =>
-    render(<TaskBar task={task} rowHeight={40} taskHeight={20} {...props} />);
+  const renderBar = (
+    task: TaskBarData = baseTask,
+    props: Partial<React.ComponentProps<typeof TaskBar>> = {}
+  ) => render(<TaskBar task={task} rowHeight={40} taskHeight={20} {...props} />);
 
   it('renders task name', () => {
     renderBar();

--- a/src/features/gantt/components/__tests__/Timeline.test.tsx
+++ b/src/features/gantt/components/__tests__/Timeline.test.tsx
@@ -14,6 +14,7 @@ const timelineData: TimelineData = {
     { name: 'Veebruar', date: new Date(2024, 1, 1), daysInMonth: 29 },
     { name: 'Märts', date: new Date(2024, 2, 1), daysInMonth: 31 },
   ],
+  weeks: []
 };
 
 const task1: TaskBarData = {
@@ -38,6 +39,20 @@ describe('Timeline', () => {
       <Timeline timelineData={timelineData} tasks={[]} rowHeight={40} taskHeight={20} />
     );
     expect(container.getElementsByClassName('month-column').length).toBe(3);
+  });
+
+  it('renders week columns when weeks provided', () => {
+    const timelineWithWeeks: TimelineData = {
+      ...timelineData,
+      weeks: [
+        { startDate: new Date(2024, 0, 1), endDate: new Date(2024, 0, 7), weekNumber: 1, days: 7 },
+        { startDate: new Date(2024, 0, 8), endDate: new Date(2024, 0, 14), weekNumber: 2, days: 7 }
+      ]
+    };
+    const { container } = render(
+      <Timeline timelineData={timelineWithWeeks} tasks={[]} rowHeight={40} taskHeight={20} />
+    );
+    expect(container.getElementsByClassName('week-column').length).toBe(2);
   });
 
   it('renders task bars', () => {

--- a/src/features/gantt/gantt.css
+++ b/src/features/gantt/gantt.css
@@ -79,6 +79,22 @@
   border-bottom: 1px solid #e5e7eb;
 }
 
+.timeline-weeks {
+  display: flex;
+}
+
+.week-header {
+  text-align: center;
+  padding: 0.25rem 0;
+  border-left: 1px solid #e5e7eb;
+  background: #f1f5f9;
+  font-size: 0.75rem;
+}
+
+.week-header.current-week {
+  background: #e0f2fe;
+}
+
 .gantt-content {
   position: relative;
   overflow: hidden;
@@ -106,12 +122,26 @@
 .timeline-grid {
   position: absolute;
   inset: 0;
+}
+
+.month-columns,
+.week-columns {
+  position: absolute;
+  inset: 0;
   display: flex;
 }
 
 .month-column {
   flex: 1;
   border-left: 1px solid #e5e7eb;
+}
+
+.week-column {
+  border-left: 1px solid #f1f5f9;
+}
+
+.week-column.current-week {
+  background: rgba(14, 165, 233, 0.1);
 }
 
 .task-bar {

--- a/src/features/gantt/types/gantt.types.ts
+++ b/src/features/gantt/types/gantt.types.ts
@@ -10,6 +10,16 @@ export interface MonthInfo {
 }
 
 /**
+ * Week information for timeline display
+ */
+export interface WeekInfo {
+  startDate: Date;
+  endDate: Date;
+  weekNumber: number;
+  days: number; // number of days of this week within the period
+}
+
+/**
  * Timeline data containing period information and month breakdown
  */
 export interface TimelineData {
@@ -25,6 +35,7 @@ export interface TimelineData {
   startDate: Date;
   endDate: Date;
   months: MonthInfo[];
+  weeks: WeekInfo[];
 }
 
 /**

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -100,3 +100,14 @@ export const isTaskInYear = (task: Task, year: number): boolean => {
   const yearEnd = getYearEnd(year);
   return task.startDate <= yearEnd && task.endDate >= yearStart;
 };
+
+/**
+ * Calculate ISO week number for a given date
+ */
+export const getWeekNumber = (date: Date): number => {
+  const tempDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = tempDate.getUTCDay() || 7;
+  tempDate.setUTCDate(tempDate.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(tempDate.getUTCFullYear(), 0, 1));
+  return Math.ceil(((tempDate.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+};


### PR DESCRIPTION
## Summary
- display weeks beneath month headers and highlight the current week
- calculate week data and ISO week numbers for timeline rendering
- add clsx dependency and fix Textarea import

## Testing
- `npm run lint`
- `npm run test:run`