### PR TITLE
Highlight current week in timeline

### DIFF
--- a/src/features/gantt/components/GanttChart.tsx
+++ b/src/features/gantt/components/GanttChart.tsx
@@ -187,7 +187,7 @@ export const GanttChart: React.FC<GanttChartProps> = ({
                 <div
                   key={`week-${week.weekNumber}-${week.startDate.toISOString()}`}
                   data-testid={`week-${week.weekNumber}`}
-                  className={`week-header${isCurrent ? ' current-week' : ''}`}
+                  className={`week-header${isCurrent ? ' current-week current' : ''}`}
                   style={{ width: `${width}%` }}
                 >
                   <span className="week-number">{week.weekNumber}</span>

--- a/src/features/gantt/components/Timeline.tsx
+++ b/src/features/gantt/components/Timeline.tsx
@@ -139,7 +139,7 @@ const TimelineComponent: React.FC<TimelineProps> = ({
             return (
               <div
                 key={`week-${week.weekNumber}-${week.startDate.toISOString()}`}
-                className={`week-column${isCurrent ? ' current-week' : ''}`}
+                className={`week-column${isCurrent ? ' current-week current' : ''}`}
                 style={{ width: `${width}%` }}
               />
             );

--- a/src/features/gantt/components/__tests__/GanttChart.test.tsx
+++ b/src/features/gantt/components/__tests__/GanttChart.test.tsx
@@ -26,6 +26,7 @@ describe('GanttChart', () => {
     const weekNumber = getWeekNumber(currentDate);
     const weekEl = screen.getByTestId(`week-${weekNumber}`);
     expect(weekEl).toHaveClass('current-week');
+    expect(weekEl).toHaveClass('current');
     vi.useRealTimers();
   });
 

--- a/src/features/gantt/gantt.css
+++ b/src/features/gantt/gantt.css
@@ -91,7 +91,8 @@
   font-size: 0.75rem;
 }
 
-.week-header.current-week {
+.week-header.current-week,
+.week-header.current {
   background: #e0f2fe;
 }
 
@@ -141,7 +142,8 @@
   border-left: 1px solid #f1f5f9;
 }
 
-.week-column.current-week {
+.week-column.current-week,
+.week-column.current {
   background: rgba(14, 165, 233, 0.1);
 }
 


### PR DESCRIPTION
## Summary
- add `current` class to current week header and columns
- style `current` class to highlight current week
- test that current week element carries `current` class

## Testing
- `npm run test:run`
- `npm run lint`
