### PR TITLE
fix: include entire week in current-week highlight

### DIFF
--- a/src/features/gantt/components/__tests__/GanttChart.test.tsx
+++ b/src/features/gantt/components/__tests__/GanttChart.test.tsx
@@ -21,6 +21,7 @@ describe('GanttChart', () => {
 
   it('renders weeks and highlights current week', () => {
     const currentDate = new Date(2024, 0, 10); // within week 2
+    vi.useFakeTimers();
     vi.setSystemTime(currentDate);
     render(<GanttChart {...baseProps} />);
     const weekNumber = getWeekNumber(currentDate);

--- a/src/features/gantt/hooks/useGanttCalculations.ts
+++ b/src/features/gantt/hooks/useGanttCalculations.ts
@@ -74,8 +74,12 @@ export const useGanttCalculations = ({
       const current = new Date(firstWeekStart);
       while (current <= endDate) {
         const weekStart = new Date(current);
+        weekStart.setHours(0, 0, 0, 0);
+
         const weekEnd = new Date(weekStart);
         weekEnd.setDate(weekEnd.getDate() + 6);
+        weekEnd.setHours(23, 59, 59, 999);
+
         const clampedStart = weekStart < startDate ? startDate : weekStart;
         const clampedEnd = weekEnd > endDate ? endDate : weekEnd;
         const days = Math.floor((clampedEnd.getTime() - clampedStart.getTime()) / msInDay) + 1;


### PR DESCRIPTION
## Summary
- cover full week range (start of Monday through end of Sunday) when building Gantt weeks so current-week highlighting works reliably

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd855a73fc832a8170ccf2b032f6fe