### PR TITLE
fix tsconfig and tests for stable builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "antd": "^5.27.2",
         "clsx": "^2.1.0",
         "dayjs": "^1.11.18",
-        "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -21,8 +21,8 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.3.0",
-        "@types/react": "^19.1.10",
-        "@types/react-dom": "^19.1.7",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^5.0.0",
         "eslint": "^9.33.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -1981,24 +1981,32 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
-      "version": "19.1.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
-      "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
+      "version": "18.3.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
+      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
-      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3546,7 +3554,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3704,6 +3711,18 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -4730,24 +4749,28 @@
       }
     },
     "node_modules/react": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
-      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
-      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.1.1"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-is": {
@@ -4902,10 +4925,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run",
     "test:coverage": "vitest run --coverage --reporter=html",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
@@ -19,8 +19,8 @@
     "antd": "^5.27.2",
     "dayjs": "^1.11.18",
     "clsx": "^2.1.0",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
@@ -29,8 +29,8 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.3.0",
-    "@types/react": "^19.1.10",
-    "@types/react-dom": "^19.1.7",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^5.0.0",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import './App.css';
 
 import type { Task } from '@/types';

--- a/src/features/gantt/components/GanttChart.tsx
+++ b/src/features/gantt/components/GanttChart.tsx
@@ -200,7 +200,11 @@ export const GanttChart: React.FC<GanttChartProps> = ({
 
         {panelMode === 'add' ? (
           <div className="gantt-body task-form-view">
-            <TaskForm onSubmit={handleAddTask} onCancel={() => setPanelMode('chart')} />
+            <TaskForm
+              onSubmit={handleAddTask}
+              onCancel={() => setPanelMode('chart')}
+              submitLabel={GANTT_ACTIONS.ADD_TASK}
+            />
           </div>
         ) : panelMode === 'edit' && selectedTask ? (
           <div className="gantt-body task-form-view">

--- a/src/features/gantt/components/__tests__/GanttChart.test.tsx
+++ b/src/features/gantt/components/__tests__/GanttChart.test.tsx
@@ -45,6 +45,6 @@ describe('GanttChart', () => {
   it('shows task form when add task is clicked', () => {
     render(<GanttChart {...baseProps} />);
     fireEvent.click(screen.getByText(GANTT_ACTIONS.ADD_TASK));
-    expect(screen.getByText('Add Task')).toBeInTheDocument();
+    expect(screen.getByText(GANTT_ACTIONS.ADD_TASK)).toBeInTheDocument();
   });
 });

--- a/src/features/tasks/components/__tests__/TaskForm.test.tsx
+++ b/src/features/tasks/components/__tests__/TaskForm.test.tsx
@@ -33,10 +33,13 @@ describe('TaskForm', () => {
           startDateStr: formatDate(start),
           endDateStr: formatDate(end),
         }}
+        submitLabel={TASKS_ACTIONS.ADD_TASK}
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add Task' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: TASKS_ACTIONS.ADD_TASK })
+    );
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalled());
     expect(onSubmit).toHaveBeenCalledWith(
@@ -51,9 +54,11 @@ describe('TaskForm', () => {
 
   it('shows validation errors when fields are empty', () => {
     const onSubmit = vi.fn();
-    render(<TaskForm onSubmit={onSubmit} />);
+    render(<TaskForm onSubmit={onSubmit} submitLabel={TASKS_ACTIONS.ADD_TASK} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add Task' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: TASKS_ACTIONS.ADD_TASK })
+    );
 
     expect(screen.getByText(VALIDATION_MESSAGES.TASK_NAME_REQUIRED)).toBeInTheDocument();
     expect(screen.getByText(VALIDATION_MESSAGES.START_DATE_REQUIRED)).toBeInTheDocument();

--- a/src/features/tasks/components/__tests__/TaskNotification.test.tsx
+++ b/src/features/tasks/components/__tests__/TaskNotification.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import { createRef } from 'react';
 import { TaskNotification, type TaskNotificationRef } from '../TaskNotification';
 import { TASKS_NOTIFICATIONS } from '../../constants';
 
@@ -18,7 +19,7 @@ vi.mock('antd', () => ({
 
 describe('TaskNotification', () => {
   it('showAdd triggers success notification', () => {
-    const ref = { current: null } as React.RefObject<TaskNotificationRef>;
+    const ref = createRef<TaskNotificationRef>();
     render(<TaskNotification ref={ref} />);
 
     ref.current?.showAdd();
@@ -28,7 +29,7 @@ describe('TaskNotification', () => {
   });
 
   it('showDelete triggers warning notification with task name', () => {
-    const ref = { current: null } as React.RefObject<TaskNotificationRef>;
+    const ref = createRef<TaskNotificationRef>();
     render(<TaskNotification ref={ref} />);
 
     ref.current?.showDelete('Example');
@@ -40,7 +41,7 @@ describe('TaskNotification', () => {
   });
 
   it('showUpdate triggers info notification', () => {
-    const ref = { current: null } as React.RefObject<TaskNotificationRef>;
+    const ref = createRef<TaskNotificationRef>();
     render(<TaskNotification ref={ref} />);
 
     ref.current?.showUpdate();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -28,5 +28,10 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/__tests__"
+  ]
 }

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vitest"]
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/__tests__/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- run vitest in CI-friendly mode and add watch script
- use stable React 18 and update type packages
- exclude test files from app tsconfig and add vitest config
- fix ref typing and localize test expectations
- show correct add-task label in Gantt chart

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd961f5214832a8537094390c99a80