### PR TITLE
Add Playwright e2e tests for task management

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npm run dev',
+    command: 'npx vite --port 5173 --strictPort --host 127.0.0.1',
     url: 'http://127.0.0.1:5173',
     reuseExistingServer: !process.env.CI,
   },

--- a/tests/e2e/tasks.spec.ts
+++ b/tests/e2e/tasks.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+const TASK_NAME = 'Test Task';
+const UPDATED_TASK_NAME = 'Updated Task';
+const START_DATE = '01.01.2024';
+const END_DATE = '05.01.2024';
+
+async function createTask(page, name = TASK_NAME) {
+  await page.getByRole('button', { name: 'Lisa ülesanne' }).click();
+  await page.getByPlaceholder('Sisestage ülesande nimi').fill(name);
+  await page.getByPlaceholder('Alguskuupäev').fill(START_DATE);
+  await page.getByPlaceholder('Lõppkuupäev').fill(END_DATE);
+  await page.getByRole('button', { name: 'Lisa ülesanne' }).click();
+}
+
+test.describe('Task management', () => {
+  test('user creates new task', async ({ page }) => {
+    await page.goto('/');
+    await createTask(page);
+    await expect(page.getByText(TASK_NAME)).toBeVisible();
+  });
+
+  test('user creates new task and modifies it', async ({ page }) => {
+    await page.goto('/');
+    await createTask(page, 'Task To Edit');
+    await page.getByText('Task To Edit').click();
+    await page.getByRole('button', { name: 'Muuda' }).click();
+    await page.getByPlaceholder('Sisestage ülesande nimi').fill(UPDATED_TASK_NAME);
+    await page.getByRole('button', { name: 'Salvesta muudatused' }).click();
+    await expect(page.getByText(UPDATED_TASK_NAME)).toBeVisible();
+  });
+
+  test('user creates new task, modifies it and deletes it', async ({ page }) => {
+    await page.goto('/');
+    await createTask(page, 'Task To Delete');
+    await page.getByText('Task To Delete').click();
+    await page.getByRole('button', { name: 'Muuda' }).click();
+    await page.getByPlaceholder('Sisestage ülesande nimi').fill(UPDATED_TASK_NAME);
+    await page.getByRole('button', { name: 'Salvesta muudatused' }).click();
+    await page.getByText(UPDATED_TASK_NAME).click();
+    await page.getByRole('button', { name: 'Kustuta' }).click();
+    await page.getByRole('button', { name: 'Jah' }).click();
+    await expect(page.getByText(UPDATED_TASK_NAME)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- configure Playwright to launch Vite on a fixed host and port
- add e2e tests covering task creation, modification and deletion

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d3f04a0832a9016b8c021f245d2