### PR TITLE
feat: add reusable delete confirmation component

### DIFF
--- a/src/components/common/DeleteConfirmation.tsx
+++ b/src/components/common/DeleteConfirmation.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Button, Flex, Space } from 'antd';
+
+export interface DeleteConfirmationProps {
+  message: string;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+export const DeleteConfirmation: React.FC<DeleteConfirmationProps> = ({
+  message,
+  onConfirm,
+  onCancel,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+}) => (
+  <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+    <p style={{ textAlign: 'center' }}>{message}</p>
+    <Flex gap="small" justify="center" style={{ paddingTop: 16 }}>
+      <Button onClick={onCancel}>{cancelLabel}</Button>
+      <Button danger onClick={onConfirm}>{confirmLabel}</Button>
+    </Flex>
+  </Space>
+);

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,5 @@
 export { ErrorDisplay } from './ErrorDisplay';
+export { DeleteConfirmation } from './DeleteConfirmation';
 
 export type { ErrorDisplayProps } from './ErrorDisplay';
+export type { DeleteConfirmationProps } from './DeleteConfirmation';

--- a/src/features/gantt/components/GanttChart.tsx
+++ b/src/features/gantt/components/GanttChart.tsx
@@ -42,9 +42,11 @@ import { Timeline } from './Timeline';
 import { TaskPanel } from './TaskPanel.tsx';
 import { useGanttCalculations } from '../hooks/useGanttCalculations';
 import { Button } from 'antd';
-import { 
+import { DeleteConfirmation } from '../../../components';
+import {
   GANTT_ACTIONS,
   GANTT_EMPTY_STATE,
+  GANTT_CONFIRMATIONS,
   formatEmptyStateMessage
 } from '../constants';
 
@@ -190,23 +192,26 @@ export const GanttChart: React.FC<GanttChartProps> = ({
           </div>
         </div>
 
-        {panelMode !== 'chart' ? (
+        {panelMode === 'confirm-delete' ? (
+          <div className="gantt-body task-delete-confirm">
+            <DeleteConfirmation
+              message={GANTT_CONFIRMATIONS.DELETE_TASK_QUESTION}
+              onConfirm={handleDeleteConfirm}
+              onCancel={() => {
+                setSelectedTask(null);
+                setPanelMode('chart');
+              }}
+              confirmLabel={GANTT_ACTIONS.YES}
+              cancelLabel={GANTT_ACTIONS.NO}
+            />
+          </div>
+        ) : panelMode !== 'chart' ? (
           <TaskPanel
-            mode={panelMode}
+            mode={panelMode as 'add' | 'details' | 'edit'}
             task={selectedTask}
             onAdd={handleAddTask}
             onEdit={handleEditSubmit}
-            onDelete={handleDeleteConfirm}
-            onCancel={
-              panelMode === 'add'
-                ? () => setPanelMode('chart')
-                : panelMode === 'confirm-delete'
-                  ? () => {
-                      setSelectedTask(null);
-                      setPanelMode('chart');
-                    }
-                  : undefined
-            }
+            onCancel={panelMode === 'add' ? () => setPanelMode('chart') : undefined}
             onCancelEdit={panelMode === 'edit' ? () => setPanelMode('details') : undefined}
             onBack={() => {
               setSelectedTask(null);

--- a/src/features/gantt/components/TaskPanel.tsx
+++ b/src/features/gantt/components/TaskPanel.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import type { Task } from '../../../types';
 import { TaskForm, DetailsView } from '../../tasks';
-import { Button, Flex, Space } from 'antd';
 import { formatDate } from '../../../utils/dateUtils';
-import { GANTT_ACTIONS, GANTT_CONFIRMATIONS } from '../constants';
+import { GANTT_ACTIONS } from '../constants';
 
 interface TaskPanelProps {
-  mode: 'add' | 'edit' | 'details' | 'confirm-delete' | 'chart';
+  mode: 'add' | 'edit' | 'details';
   task: Task | null;
   onAdd?: (task: Omit<Task, 'id'>) => Promise<void> | void;
   onEdit?: (task: Omit<Task, 'id'>) => Promise<void> | void;
-  onDelete?: () => Promise<void> | void;
-  onCancel?: () => void; // Used for add form cancel and delete confirmation cancel
+  onCancel?: () => void; // Used for add form cancel
   onCancelEdit?: () => void; // Used for edit form cancel
   onBack?: () => void; // Used for details back to chart
   onEditClick?: () => void; // Used for details edit button
@@ -29,7 +27,6 @@ export const TaskPanel: React.FC<TaskPanelProps> = ({
   task,
   onAdd,
   onEdit,
-  onDelete,
   onCancel,
   onCancelEdit,
   onBack,
@@ -69,20 +66,6 @@ export const TaskPanel: React.FC<TaskPanelProps> = ({
         onBack={onBack!}
         onDelete={onDeleteClick!}
       />
-    );
-  }
-
-  if (mode === 'confirm-delete' && task) {
-    return (
-      <div className="gantt-body task-delete-confirm">
-        <Space direction="vertical" size="middle" style={{ width: '100%' }}>
-          <p style={{ textAlign: 'center' }}>{GANTT_CONFIRMATIONS.DELETE_TASK_QUESTION}</p>
-          <Flex gap="small" justify="center" style={{ paddingTop: 16 }}>
-            <Button onClick={onCancel}>{GANTT_ACTIONS.NO}</Button>
-            <Button danger onClick={onDelete}>{GANTT_ACTIONS.YES}</Button>
-          </Flex>
-        </Space>
-      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
- create reusable DeleteConfirmation component
- simplify TaskPanel by removing inline delete confirmation view
- integrate DeleteConfirmation into GanttChart with proper labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be94d8ab70832abd5bf0cefa5378dd