### PR TITLE
feat(gantt): add responsive toggle task button

### DIFF
--- a/src/features/gantt/components/GanttChart.tsx
+++ b/src/features/gantt/components/GanttChart.tsx
@@ -41,7 +41,6 @@ import { QuarterNavigation } from './QuarterNavigation';
 import { Timeline } from './Timeline';
 import { TaskPanel } from '../../tasks';
 import { useGanttCalculations } from '../hooks/useGanttCalculations';
-import { Button } from 'antd';
 import { DeleteConfirmation } from '../../../components';
 import {
   GANTT_ACTIONS,
@@ -49,6 +48,7 @@ import {
   GANTT_CONFIRMATIONS,
   formatEmptyStateMessage
 } from '../constants';
+import { ToggleTaskButton } from './ToggleTaskButton';
 
 interface GanttChartProps {
   tasks: Task[];
@@ -141,10 +141,9 @@ export const GanttChart: React.FC<GanttChartProps> = ({
             onQuarterChange={handleQuarterChange}
             disabled={panelMode !== 'chart'}
           />
-          <Button
-            htmlType="button"
-            icon={panelMode === 'chart' ? '+' : '×'}
-            onClick={() => {
+          <ToggleTaskButton
+            panelMode={panelMode}
+            onToggle={() => {
               if (panelMode === 'chart') {
                 setPanelMode('add');
               } else {
@@ -152,14 +151,25 @@ export const GanttChart: React.FC<GanttChartProps> = ({
                 setSelectedTask(null);
               }
             }}
-          >
-            {panelMode === 'chart' ? GANTT_ACTIONS.ADD_TASK : GANTT_ACTIONS.VIEW_CHART}
-          </Button>
+            className="desktop"
+          />
         </div>
       </div>
 
       {/* Chart content */}
       <div className={`gantt-content ${viewMode === 'year' ? 'year-view' : ''}`}>
+        <ToggleTaskButton
+          panelMode={panelMode}
+          onToggle={() => {
+            if (panelMode === 'chart') {
+              setPanelMode('add');
+            } else {
+              setPanelMode('chart');
+              setSelectedTask(null);
+            }
+          }}
+          className="mobile"
+        />
         {/* Timeline months header */}
         <div className="timeline-header">
           <div className="timeline-months">

--- a/src/features/gantt/components/ToggleTaskButton.tsx
+++ b/src/features/gantt/components/ToggleTaskButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button } from 'antd';
+import { GANTT_ACTIONS } from '../constants';
+
+interface ToggleTaskButtonProps {
+  panelMode: 'chart' | 'add' | 'details' | 'edit' | 'confirm-delete';
+  onToggle: () => void;
+  className?: string;
+}
+
+export const ToggleTaskButton: React.FC<ToggleTaskButtonProps> = ({
+  panelMode,
+  onToggle,
+  className = '',
+}) => {
+  const isChart = panelMode === 'chart';
+
+  return (
+    <Button
+      htmlType="button"
+      icon={isChart ? '+' : '×'}
+      onClick={onToggle}
+      className={`toggle-task-button ${className}`.trim()}
+    >
+      {isChart ? GANTT_ACTIONS.ADD_TASK : GANTT_ACTIONS.VIEW_CHART}
+    </Button>
+  );
+};
+
+export default ToggleTaskButton;

--- a/src/features/gantt/components/__tests__/GanttChart.test.tsx
+++ b/src/features/gantt/components/__tests__/GanttChart.test.tsx
@@ -42,9 +42,17 @@ describe('GanttChart', () => {
     expect(baseProps.onQuarterChange).toHaveBeenCalledWith(2024, 2);
   });
 
-  it('shows task form when add task is clicked', () => {
+  it('toggles between chart view and add task form', () => {
     render(<GanttChart {...baseProps} />);
-    fireEvent.click(screen.getByText(GANTT_ACTIONS.ADD_TASK));
+    const addButtons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.textContent?.includes(GANTT_ACTIONS.ADD_TASK));
+    fireEvent.click(addButtons[0]);
     expect(screen.getByText(GANTT_ACTIONS.ADD_TASK)).toBeInTheDocument();
+    const viewButtons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.textContent?.includes(GANTT_ACTIONS.VIEW_CHART));
+    fireEvent.click(viewButtons[0]);
+    expect(screen.getByText('Jaanuar')).toBeInTheDocument();
   });
 });

--- a/src/features/gantt/gantt.css
+++ b/src/features/gantt/gantt.css
@@ -101,6 +101,15 @@
   overflow: hidden;
 }
 
+.toggle-task-button {
+  display: inline-flex;
+  align-items: center;
+}
+
+.toggle-task-button.mobile {
+  display: none;
+}
+
 .gantt-body {
   position: relative;
 }
@@ -214,6 +223,20 @@
   .gantt-content.year-view .timeline-header,
   .gantt-content.year-view .gantt-body {
     min-width: 1000px;
+  }
+}
+
+@media (max-width: 600px) {
+  .toggle-task-button.desktop {
+    display: none;
+  }
+
+  .toggle-task-button.mobile {
+    display: block;
+    position: absolute;
+    bottom: 1rem;
+    right: 1rem;
+    z-index: 10;
   }
 }
 


### PR DESCRIPTION
## Summary
- add reusable `ToggleTaskButton` component with mode-aware icons and labels
- use `ToggleTaskButton` in `GanttChart` toolbar and as floating mobile button
- style toggle button for desktop/mobile and adjust tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9fd5ad84832a81b053665a139b76